### PR TITLE
Dependencies update

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
-				<version>3.5.1</version>
+				<version>3.6.1</version>
 				<configuration>
 					<source>1.8</source>
 					<target>1.8</target>
@@ -20,6 +20,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-shade-plugin</artifactId>
+				<version>3.0.0</version>
 				<executions>
 					<execution>
 						<phase>package</phase>
@@ -29,7 +30,7 @@
 					</execution>
 				</executions>
 				<configuration>
-					<finalName>uber-${artifactId}-${version}</finalName>
+					<finalName>uber-${project.artifactId}-${project.version}</finalName>
 				</configuration>
 			</plugin>
 		</plugins>
@@ -46,17 +47,17 @@
 			<dependency>
 				<groupId>org.deeplearning4j</groupId>
 				<artifactId>deeplearning4j-core</artifactId>
-				<version>0.4-rc3.9</version>
+				<version>0.8.0</version>
 			</dependency>
 			<dependency>
 				<groupId>org.nd4j</groupId>
 				<artifactId>nd4j-native</artifactId>
-				<version>0.4-rc3.9</version>
+				<version>0.8.0</version>
 			</dependency>
 			<dependency>
 				<groupId>org.nd4j</groupId>
 				<artifactId>canova-api</artifactId>
-				<version>0.0.0.13</version>
+				<version>0.0.0.17</version>
 			</dependency>
 		</dependencies>
 	</dependencyManagement>
@@ -66,32 +67,32 @@
 		<dependency>
 			<groupId>org.tukaani</groupId>
 			<artifactId>xz</artifactId>
-			<version>1.5</version>
+			<version>1.6</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.commons</groupId>
 			<artifactId>commons-lang3</artifactId>
-			<version>3.0</version>
+			<version>3.5</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.commons</groupId>
 			<artifactId>commons-math3</artifactId>
-			<version>3.5</version>
+			<version>3.6.1</version>
 		</dependency>
 		<dependency>
 			<groupId>com.google.guava</groupId>
 			<artifactId>guava</artifactId>
-			<version>18.0</version>
+			<version>22.0-rc1</version>
 		</dependency>
 		<dependency>
 			<groupId>commons-io</groupId>
 			<artifactId>commons-io</artifactId>
-			<version>2.4</version>
+			<version>2.5</version>
 		</dependency>
 		<dependency>
 			<groupId>com.google.code.gson</groupId>
 			<artifactId>gson</artifactId>
-			<version>2.4</version>
+			<version>2.8.0</version>
 		</dependency>
 		<dependency>
 			<groupId>org.deeplearning4j</groupId>
@@ -100,7 +101,7 @@
 		<dependency>
 			<groupId>org.deeplearning4j</groupId>
 			<artifactId>deeplearning4j-ui</artifactId>
-			<version>0.4-rc3.9</version>
+			<version>0.6.0</version>
 		</dependency>
 		<dependency>
 			<groupId>org.nd4j</groupId>
@@ -113,18 +114,18 @@
 		<dependency>
 			<groupId>org.nd4j</groupId>
 			<artifactId>nd4j-api</artifactId>
-			<version>0.4-rc3.9</version>
+			<version>0.8.0</version>
 		</dependency>
 		<dependency>
 			<groupId>cc.mallet</groupId>
 			<artifactId>mallet</artifactId>
-			<version>2.0.7</version>
+			<version>2.0.8</version>
 		</dependency>
 		<!-- http://mvnrepository.com/artifact/edu.stanford.nlp/stanford-corenlp -->
 		<dependency>
 			<groupId>edu.stanford.nlp</groupId>
 			<artifactId>stanford-corenlp</artifactId>
-			<version>3.6.0</version>
+			<version>3.7.0</version>
 		</dependency>
 	</dependencies>
 </project>

--- a/src/gr/aueb/cs/nlp/computationgraphs/GraphConfigurations.java
+++ b/src/gr/aueb/cs/nlp/computationgraphs/GraphConfigurations.java
@@ -11,6 +11,7 @@ import org.deeplearning4j.nn.conf.layers.GravesLSTM;
 import org.deeplearning4j.nn.conf.layers.OutputLayer;
 import org.deeplearning4j.nn.conf.layers.RnnOutputLayer;
 import org.nd4j.linalg.lossfunctions.LossFunctions.LossFunction;
+import org.nd4j.linalg.activations.Activation;
 
 import gr.aueb.cs.nlp.wordtagger.data.structure.Word;
 
@@ -49,13 +50,13 @@ public class GraphConfigurations {
 		ComputationGraphConfiguration conf = new NeuralNetConfiguration.Builder()
 		        .learningRate(0.01)
 		        .regularization(true) //else it won't use regularizers
-		        .graphBuilder()
+		        .graphBuilder() 
 		        .addInputs("input") //can use any label for this, it is just an identifier for the graph.
-		        .addLayer("L1", new DenseLayer.Builder()
+		        .addLayer("L1", new DenseLayer.Builder() 
 		        		.nIn(inputFeatures) // always current nIn = Sum(nOut) of layer inputs
 		        		.nOut(300)	//you have as many neurons as your outputs...
 		        		.biasLearningRate(0.2) //faster changing bias int he first layer then slower
-		        		.activation(ActivationFunction.relu.name()) // the enumerations are made by me, 
+		        		.activation(Activation.RELU) // the enumerations are made by me, 
 		        													//to help me know which activations are available,
 		        													//for me relu work so often but they need more neurons per layer than others
 		        		.l1(0.3) //l1 regularization
@@ -72,7 +73,7 @@ public class GraphConfigurations {
 		        		.biasLearningRate(0.02)
 		        		.l1(0.3)
 		        		.l2(0.02)
-		        		.activation(ActivationFunction.relu.name()) 
+		        		.activation(Activation.RELU) 
 		        		.dropOut(0.3)
 		        		.updater(Updater.ADAM)//how to use ADAM, read the ADAM paper 
 		        							  //to understand better what they do https://arxiv.org/pdf/1412.6980.pdf
@@ -84,7 +85,7 @@ public class GraphConfigurations {
 		        		.nIn(250) // an autoencoder for some feature extraction
 		        		.nOut(300)
 		        		.biasLearningRate(0.02)
-		        		.activation(ActivationFunction.relu.name()) 
+		        		.activation(Activation.RELU) 
 		        		.l1(0.1)
 		        		.l2(0.1)
 		        		.dropOut(0.3)
@@ -95,7 +96,7 @@ public class GraphConfigurations {
 		        		.biasLearningRate(0.03)
 		        		.l1(0.1)
 		        		.l2(0.1)
-		        		.activation(ActivationFunction.relu.name()) 
+		        		.activation(Activation.RELU) 
 		        		.dropOut(0.3)
 		        		.build(), "L3")
 		        .addLayer("L5",new OutputLayer.Builder()
@@ -104,7 +105,7 @@ public class GraphConfigurations {
 		        		.lossFunction(LossFunction.MCXENT)	//categorical cross entropy, when building the output layer be very careful
 		        											//about pairing the right loss function with the appropriate activation
 		        											//e.g. why can't sigmoid work with hinge loss? cause [0,1] != [-1,1]
-		        		.activation(ActivationFunction.softmax.name()) //softmax goes with categorical corss entropy
+		        		.activation(Activation.SOFTMAX) //softmax goes with categorical corss entropy
 		        		.build(),  "L4")
 		        .setOutputs("L5")	//We need to specify the network outputs and their order
 		        .build();
@@ -133,7 +134,7 @@ public class GraphConfigurations {
 		        		.nIn(inputFeatures) // always current nIn = Sum(nOut) of layer inputs
 		        		.nOut(150)	//you have as many neurons as your outputs...
 		        		.biasLearningRate(0.2) //faster changing bias int he first layer then slower
-		        		.activation(ActivationFunction.tanh.name()) // the enumerations are made by me, 
+		        		.activation(Activation.TANH) // the enumerations are made by me, 
 		        													//to help me know which activations are available,
 		        													//for me relu work so often but they need more neurons per layer than others
 		        		.l1(0.3) //l1 regularization
@@ -150,7 +151,7 @@ public class GraphConfigurations {
 		        		.biasLearningRate(0.02)
 		        		.l1(0.3)
 		        		.l2(0.02)
-		        		.activation(ActivationFunction.relu.name()) 
+		        		.activation(Activation.RELU) 
 		        		.dropOut(0.3)
 		        		.updater(Updater.ADAM)//how to use ADAM, read the ADAM paper 
 		        							  //to understand better what they do https://arxiv.org/pdf/1412.6980.pdf

--- a/src/gr/aueb/cs/nlp/main/ExperimentTest.java
+++ b/src/gr/aueb/cs/nlp/main/ExperimentTest.java
@@ -1,6 +1,7 @@
 package gr.aueb.cs.nlp.main;
 
 import java.io.File;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
@@ -24,7 +25,10 @@ import gr.aueb.cs.nlp.wordtagger.data.structure.Model;
 import gr.aueb.cs.nlp.wordtagger.data.structure.Word;
 import gr.aueb.cs.nlp.wordtagger.data.structure.WordSet;
 import gr.aueb.cs.nlp.wordtagger.data.structure.features.FeatureBuilder;
+import gr.aueb.cs.nlp.wordtagger.data.structure.features.FeatureVector;
 import gr.aueb.cs.nlp.wordtagger.experiment.ExperimentSetup;
+import gr.aueb.cs.nlp.wordtagger.util.CallBack;
+import gr.aueb.cs.nlp.wordtagger.util.FileHelper;
 
 /**
  * 
@@ -65,13 +69,13 @@ public class ExperimentTest {
 		
 		// qnStatFeatsTrainSmall();
 		// qnStatFeatsTrainBig();
-		// crfFeatsTrainSmall();
+		crfFeatsTrainSmall();
 		// qnStatFeatsTrainBig();
 		// svmStatFeatsTrainBig();
 		// System.gc();
 		// crfStatFeatsTrainBig();
 		// walkFiles("C:/Users/Thomas/Desktop/emb2");
-		 dmlpStatFeatsTrainSmall();
+		// dmlpStatFeatsTrainSmall(); //put in comment in
 		// lstmStatFeatsTrainSmall();
 		// votingSmallStatistical();
 		// qnStatEmbTrainBig("resources/data/vecs/wikipedia/v_300","");
@@ -269,24 +273,39 @@ public class ExperimentTest {
 	}
 
 	public static void crfStatFeatsTrainBig() {
+		//...create file
+		//SongTokenizer.tokenizeToFile(S lyrics, pathTowrite);
+		
+		
 		Model model = new Model(Resources.HIGH_CATS, 3);
 		MetaTagger meta = new MetaTagger(model, Resources.HIGH_GAZZETE);
 		Evaluation eval = new Evaluation(meta, true, false);
-		ExperimentSetup exs = new ExperimentSetup.Builder().setLookAhead(0).setClassifier(new SVMClassifier())
-				.setLookBehind(0).setTotalShards(1).setClassifier(new CRFClassifier(1, 2, 10))
+		ExperimentSetup exs = new ExperimentSetup.Builder()
+				.setLookAhead(0)
+				.setClassifier(new SVMClassifier())
+				.setLookBehind(0)
+				.setTotalShards(1)
+				.setClassifier(new CRFClassifier(1, 2, 10))
 				.setCategoriesPath(Resources.HIGH_CATS)
 				.setTrainPath(Resources.TRAIN_HIGH)
 				.setTestPath(Resources.TEST_HIGH).setEval(eval).setEvalToCSV(true)
-				.setEvalLocation(Resources.EVAL_DIRECTORY + "evalCRFBIG.csv").setModel(model).build();
+				.setEvalLocation(Resources.EVAL_DIRECTORY + "evalCRFBIG.csv")
+				.setModel(model)
+				.build();
 		exs.execute();
 	}
 
 	public static void crfFeatsTrainSmall() {
-		ExperimentSetup exs = new ExperimentSetup.Builder().setClassifier(new CRFClassifier(1, 0, 15)).setTotalShards(1)
-				.setLookAhead(0).setLookBehind(0).setEvalToCSV(true).setEvalLocation("C:/Users/Thomas/Desktop/eval.csv")
+		ExperimentSetup exs = new ExperimentSetup.Builder()
+				.setClassifier(new CRFClassifier(1, 0, 15))
+				.setTotalShards(1)
+				.setTrainPath("resources/data/train/train_low")
+				.setTestPath("resources/data/train/train_low")
+				.setEvalLocation("resources/eval.csv")
 				.build();
 		exs.execute();
 
 	}
 
+	
 }

--- a/src/gr/aueb/cs/nlp/wordtagger/classifier/MaxEntClassifier.java
+++ b/src/gr/aueb/cs/nlp/wordtagger/classifier/MaxEntClassifier.java
@@ -49,7 +49,8 @@ public class MaxEntClassifier implements Classifier, Serializable {
 	 * and then stopping the algorithm, if it is smaller than tolerance.
 	 */
 	public MaxEntClassifier(boolean verbose, int maxIterations, int memStates, double tolerance){
-		LinearClassifierFactory<String, String> factory = new LinearClassifierFactory<>(tolerance);
+		LinearClassifierFactory<String, String> factory = new LinearClassifierFactory<>();
+		factory.setTol(tolerance);
 		Factory<Minimizer<DiffFunction>> minimizerCreator = customQN(verbose, maxIterations, memStates);
 		factory.setMinimizerCreator(minimizerCreator);
 		this.classifierFactory = factory;


### PR DESCRIPTION
This pull request is made to cover the issue  [#1](https://github.com/tomdev55/word.tagging/issues/1) .

I have updated the dependencies to follow the latest versions that have been released in the maven repository.
Most of the packages were some versions ahead of the ones declared originally. Bellow are listed the changes in detail.

	line 14, change of  maven-compiler-plugin version from 3.5.1 to 3.6.1
	line 23, addition of the maven shade plugin version (after notification from Maven)
	line 33: update of fields artifactId and version due to compatibility reasons(prompt by 
                     maven for security issues)
	line 50, change of  deeplearning4j-core version from 0.4-rc3.9 to 0.8.0
	line 55, change of nd4j-native version from 0.4-rc3.9 to 0.8.0
	line 60, change of canova-api version from 0.0.0.13 to 0.0.0.17
	line 70, change of xz version from 1.5 to 1.6
	line 75, change of commons-lag3 version from 3.0 to 3.5
	line 80, change of commons-math3 version from 3.5 to 3.6.1
	line 85, change of guava version from 18.0 to 22.0-rc1
	line 90, change of commons-io version from 2.4 to 2.5
	line 95, change of gson version from 2.4 to 2.8.0
	line 104, change of deeplearning4j-ui version from 0.4-rc3.9 to 0.6.0
	line 117, change of nd4j-api version from 0.4-rc3.9 to 0.8.0
	line 122, change of mallet version from 2.0.7 to 2.0.8
	line 128, change of stanford-corenlp version from 3.6.0 to 3.7.0
	
The version change of nd4j-api created some issues in src/gr/aueb/cs/nlp/computaiongraphs/GraphConfigurations.java, due to a change in the Activation function provided by the package. For this reason, the implemantation of the function  had to be adjusted to the changes(line 59, 76, 88, 99, 108, 137, 154) so that it would suit the implemantation in the 
following package: org.nd4j.linalg.activations.Activation