### PR TITLE
Bug fix in SongTokenizer, improved the tests

### DIFF
--- a/src/gr/aueb/cs/nlp/wordtagger/tokenizer/SongTokenizer.java
+++ b/src/gr/aueb/cs/nlp/wordtagger/tokenizer/SongTokenizer.java
@@ -64,7 +64,6 @@ public class SongTokenizer implements Tokenizer {
 				+ File.separator + "Soft_Engine"
 				+ File.separator + "lyricsTest");
 		sr.tokenize(rawSongText);
-		int i = 0;
 		for (String s:songAnalysed) {
 			System.out.println(s);
 		}
@@ -79,7 +78,8 @@ public class SongTokenizer implements Tokenizer {
 	 * 	containing either a token or a word from the song.
 	 */
 	public List<String> tokenize(String rawSongText) {
-
+		songAnalysed.clear();
+		songAnalysedTemp.clear();
 		/*
 		 * FIRST CLEANUP
 		 * here we clean up our input from puncuation marks (,.!"')

--- a/src/test/SongTokenizerTest.java
+++ b/src/test/SongTokenizerTest.java
@@ -33,6 +33,8 @@ public class SongTokenizerTest {
 							+ "[Tell 'em that God's gonna cut 'em down]x2";
 	
 	static List<String> songLyricsTokenized = new ArrayList<String>();
+	static List<String> songLyricsToTest = new ArrayList<String>();
+
 	final static String verseRegex = "(\n\n)";
 	final static String verseToken = "|<new verse>|";
 	
@@ -67,11 +69,10 @@ public class SongTokenizerTest {
 	 * as well.
 	 */
 	public void tokenizeTest(){
-		songLyricsTokenized.clear();
 		songLyricsTokenizedSet();
-		List<String> songLyricsToTest = new ArrayList<String>();
 		SongTokenizer songTokenizerTest = new SongTokenizer();
-		songLyricsToTest = songTokenizerTest.tokenize(songLyrics);
+		songLyricsToTest.clear();
+		songLyricsToTest.addAll(songTokenizerTest.tokenize(songLyrics));
 		Assert.assertEquals(songLyricsToTest, songLyricsTokenized);
 	} //end of tokenizeTest()
 
@@ -80,6 +81,7 @@ public class SongTokenizerTest {
 	 * values we should see after a tokenization process occurs
 	 */
 	public void songLyricsTokenizedSet(){
+		songLyricsTokenized.clear();
 		songLyricsTokenized.add(verseToken);
 		songLyricsTokenized.add(lyricToken);
 		songLyricsTokenized.add("You");

--- a/src/test/TestRunner.java
+++ b/src/test/TestRunner.java
@@ -4,8 +4,16 @@ import org.junit.runner.JUnitCore;
 import org.junit.runner.Result;
 import org.junit.runner.notification.Failure;
 
+/**
+ * This class initializes all the other tests and
+ * prints the results.
+ * 
+ * @author Alexandros
+ * @since 6/2017
+ */
 public class TestRunner {
 	public static void main(String[] args){
+		TestRunner tr = new TestRunner();
 		Result result = JUnitCore.runClasses(BreakTypeTest.class, 
 					SongHelperTest.class, SongTokenizerTest.class);
 		for(Failure failure : result.getFailures()){


### PR DESCRIPTION
While running the tests once more, a bug was spotted in SongTokenizer.tokenize method. Because the class uses static lists for the tokenization process, if the class was called twice by another class(like what happened in the test class), it was possible for the list to have the content already stored in it before the process begun. Therefore, the list would sometimes return what was run before as well as the results wanted. This was fixed by cleaning the list before any tokenization occurs. 

Also imrpoved the test class SongTokenizerTest in matters of syntax.